### PR TITLE
scan: switch to calling them "rounds" instead of "commits"

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,13 @@ compared to the stake.
 
 ## Main data development graph
 
-The graphs gather data from many builds. Several builds may have been done
-based on the same commit. The data from all builds for each commit is
-accumulated and the *median*, *minimum* and *maximum* values are put into the
-graph.
+The graphs gather data from many builds into a single *round*. Several builds
+may have been done in the same round. The data from all builds in the same
+round is accumulated and the *median*, *minimum* and *maximum* values are put
+into the graph.
+
+As long as the commit does not change when new builds are done, the round
+continues.
 
 There are three additional plots in the graph:
 
@@ -105,12 +108,14 @@ There are three additional plots in the graph:
 - *moving average* is the mean value of the 4 latest commits' (median)
   values
 
-The leftmost datapoint is the oldest commit. Later ones move to the right.
+The leftmost datapoint is the oldest build round. Later ones move to the
+right.
 
 The Y axis unit depends on the specific test. Read the description.
 
-The X axis are the different commits. The commits are shown as `C[number]`. At
-the top of the page there are direct links for each commit.
+The X axis are the different rounds. Each build round is shown as `R[number]`.
+At the top of the page there are direct links for the last commit for each
+round, as long as additional details about them.
 
 ## Data distribution graph
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ There are three additional plots in the graph:
 
 - *mean* is the mean value taken from all builds in the set
 - *stake* is the predetermined (ideal) value to compare against for this test
-- *moving average* is the mean value of the 4 latest commits' (median)
+- *moving average* is the mean value of the 4 latest rounds' (median)
   values
 
 The leftmost datapoint is the oldest build round. Later ones move to the

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ may have been done in the same round. The data from all builds in the same
 round is accumulated and the *median*, *minimum* and *maximum* values are put
 into the graph.
 
-As long as the commit does not change when new builds are done, the round
-continues.
+If the latest commit remains the same as the previous one when a new build is
+started, the round continues.
 
 There are three additional plots in the graph:
 

--- a/scan.pl
+++ b/scan.pl
@@ -361,7 +361,7 @@ sub show {
     storelttb($filename, @o);
     
     print "<pre>\n";
-    printf "%u samples, %u commits\n", scalar(values %a), scalar(@o);
+    printf "%u samples, %u rounds\n", scalar(values %a), scalar(@o);
     printf "P0:      %s\n", showval($p0);
     printf "P25:     %s\n", showval($p25);
     printf "P50:     %s\n", showval($p50);
@@ -408,7 +408,7 @@ sub show {
     showdocs($filename);
     print "</details>\n";
 
-    print "<h3>Most recent $numlast commits</h3>\n";
+    print "<h3>Most recent $numlast rounds</h3>\n";
     print "<img src=\"$filename-$suffix.svg\">\n";
     print "<details><summary>Data distribution</summary>\n";
     print "<h3>Data distribution</h3>\n";
@@ -718,7 +718,7 @@ for my $c (sort keys %git) {
     $gitcommits{$git{$c}}++;
     if($gitcommits{$git{$c}} == 1) {
         push @inorder, $git{$c};
-        $gitalias{$git{$c}} = sprintf("C%u", $short);
+        $gitalias{$git{$c}} = sprintf("R%u", $short);
         $short++;
     }
 }
@@ -736,7 +736,7 @@ print <<HEAD
 $numlogs builds analyzed. Last run ended $done (Daniel's local time). This
 page was rendered at $now.
 
-<details><summary>$numcommits commits</summary>
+<details><summary>$numcommits rounds</summary>
 <p>
 
 HEAD

--- a/scan.pl
+++ b/scan.pl
@@ -723,7 +723,7 @@ for my $c (sort keys %git) {
     }
 }
 
-my $numcommits = scalar(keys %gitcommits);
+my $numrounds = scalar(keys %gitcommits);
 
 my $numlogs = scalar(@logs);
 use POSIX qw(strftime);
@@ -736,7 +736,7 @@ print <<HEAD
 $numlogs builds analyzed. Last run ended $done (Daniel's local time). This
 page was rendered at $now.
 
-<details><summary>$numcommits rounds</summary>
+<details><summary>$numrounds rounds</summary>
 <p>
 
 HEAD


### PR DESCRIPTION
Since each round can in fact incorporate a number of new commits, it makes sense to separate the words. Change the aliases to be R prefixed.